### PR TITLE
Add parametrizations for sheaf restriction maps in Structured Embedding

### DIFF
--- a/sheaf_kg/models/multisection_structured_embedding.py
+++ b/sheaf_kg/models/multisection_structured_embedding.py
@@ -2,9 +2,10 @@
 
 """Implementation of structured model (SE)."""
 
-from typing import Any, ClassVar, Mapping, Optional
+from typing import Any, Callable, ClassVar, Mapping, Optional
 
 from class_resolver import Hint, HintOrType, OptionalKwargs
+from torch import nn
 from torch.nn import functional
 
 from pykeen.models.nbase import ERModel
@@ -13,8 +14,13 @@ from pykeen.nn.init import xavier_uniform_, xavier_uniform_norm_
 from pykeen.typing import Constrainer, Initializer
 from pykeen.regularizers import Regularizer
 
-from sheaf_kg.interactions.multisection_structured_embedding import MultisectionStructuredEmbeddingInteraction
-from sheaf_kg.regularizers.multisection_regularizers import OrthogonalSectionsRegularizer
+from sheaf_kg.interactions.multisection_structured_embedding import (
+    MultisectionStructuredEmbeddingInteraction,
+)
+from sheaf_kg.regularizers.multisection_regularizers import (
+    OrthogonalSectionsRegularizer,
+)
+from sheaf_kg.representations.parameterized_embedding import ParameterizedEmbedding
 
 __all__ = [
     "MultisectionSE",
@@ -34,7 +40,7 @@ class MultisectionStructuredEmbedding(ERModel):
         *,
         C0_dimension: int = 50,
         num_sections: int = 3,
-        C1_dimension = 20,
+        C1_dimension=20,
         scoring_fct_norm: int = 2,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         entity_constrainer: Hint[Constrainer] = functional.normalize,
@@ -42,6 +48,7 @@ class MultisectionStructuredEmbedding(ERModel):
         regularizer_kwargs: OptionalKwargs = None,
         entity_constrainer_kwargs: Optional[Mapping[str, Any]] = None,
         relation_initializer: Hint[Initializer] = xavier_uniform_norm_,
+        relation_parametrization: Optional[Callable] = None,
         **kwargs,
     ) -> None:
         r"""Initialize SE.
@@ -62,21 +69,24 @@ class MultisectionStructuredEmbedding(ERModel):
                 # power_norm=True,
             ),
             entity_representations_kwargs=dict(
-                shape=(C0_dimension,num_sections),
+                shape=(C0_dimension, num_sections),
                 initializer=entity_initializer,
                 constrainer=entity_constrainer,
                 constrainer_kwargs=entity_constrainer_kwargs,
                 regularizer=regularizer,
                 regularizer_kwargs=regularizer_kwargs,
             ),
+            relation_representations=ParameterizedEmbedding,
             relation_representations_kwargs=[
                 dict(
                     shape=(C1_dimension, C0_dimension),
                     initializer=relation_initializer,
+                    parametrization=relation_parametrization,
                 ),
                 dict(
                     shape=(C1_dimension, C0_dimension),
                     initializer=relation_initializer,
+                    parametrization=relation_parametrization,
                 ),
             ],
             **kwargs,

--- a/sheaf_kg/representations/parameterized_embedding.py
+++ b/sheaf_kg/representations/parameterized_embedding.py
@@ -1,0 +1,63 @@
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
+
+from pykeen.nn.representation import Embedding, Regularizer
+from pykeen.typing import (
+    Constrainer,
+    Hint,
+    HintType,
+    Initializer,
+    Normalizer,
+    OneOrSequence,
+)
+
+import torch
+import torch.nn.utils.parametrize as parametrize
+from torch import nn
+
+
+class ParameterizedEmbedding(Embedding):
+    """Embeddings with an optional Torch parametrization.
+
+    parametrization may be one of the two functions in
+    torch.nn.utils.parametrizations, or a function that has the same
+    behavior.
+    """
+
+    normalizer: Optional[Normalizer]
+    constrainer: Optional[Constrainer]
+    regularizer: Optional[Regularizer]
+    dropout: Optional[nn.Dropout]
+
+    def __init__(
+        self,
+        max_id: Optional[int] = None,
+        num_embeddings: Optional[int] = None,
+        embedding_dim: Optional[int] = None,
+        shape: Union[None, int, Sequence[int]] = None,
+        initializer: Hint[Initializer] = None,
+        initializer_kwargs: Optional[Mapping[str, Any]] = None,
+        constrainer: Hint[Constrainer] = None,
+        constrainer_kwargs: Optional[Mapping[str, Any]] = None,
+        parametrization: Callable[[nn.Module], nn.Module] = None,
+        trainable: bool = True,
+        dtype: Optional[torch.dtype] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            max_id=max_id,
+            num_embeddings=num_embeddings,
+            embedding_dim=embedding_dim,
+            shape=shape,
+            initializer=initializer,
+            initializer_kwargs=initializer_kwargs,
+            constrainer=constrainer,
+            constrainer_kwargs=constrainer_kwargs,
+            trainable=trainable,
+            dtype=dtype,
+            **kwargs,
+        )
+        if parametrization is not None:
+            # parametrize.register_parametrization(
+            #     self._embeddings, "_weight", parametrization
+            # )
+            self._embeddings = parametrization(self._embeddings, name="weight")


### PR DESCRIPTION
This adds the routing necessary to apply parametrizations from the `torch.nn.utils.parametrizations` module to the restriction maps for relations in Structured Embedding models. The two options are therefore orthogonal maps and unit-spectral-norm maps, along with whatever else you can implement by hand.

I've given this cursory testing and it seems to do the right thing, while somewhat slower than the nonparametrized version.

I'm not sure yet how to extend this to models where there are translational components, since right now it just applies the same parametrization to every piece of the representation.